### PR TITLE
Fix for Some CM 13's not being able to enable bluetooth then eventually crashing

### DIFF
--- a/www/js/index.js
+++ b/www/js/index.js
@@ -390,7 +390,9 @@ mainPage = new Page("main",
         if (app.bluetoothInitialized) {
             // after bluetooth is disabled, it's automatically re-enabled.
             //this.beginRefreshData();
-            app.disableBluetooth();
+            if (device.version[0] == '4')
+              app.disableBluetooth();
+
         }
     },
     function onHide() {
@@ -1126,6 +1128,7 @@ app = {
         });
     },
     disableBluetooth: function() {
+
         app.watchdogEnd();
         app.stopScan();
         console.log("Disabling Bluetooth!");


### PR DESCRIPTION
Tested on:
- 2x CM 13 (these are the only devices known to have suffered from the issue; android version 6.0.1)
- 2x CM 12.1
- Android 4.4.4


Via:
- Restarting app multiple times and ensuring does not crash and is able to scan
- Starting app with bluetooth disabled and ensuring enables and scans upon start
- Have app scanning, then manually disable bluetooth and ensure bluetooth automatically enables and continues to scan